### PR TITLE
Conflict with pytest-black

### DIFF
--- a/pytest_azurepipelines.py
+++ b/pytest_azurepipelines.py
@@ -25,6 +25,10 @@ def pytest_addoption(parser):
 
 def pytest_collection_modifyitems(session, config, items):
     for item in items:
+        # Make sure that nodes have required attributes
+        if not hasattr(item, "obj") or not hasattr(item.parent, "obj"):
+            continue
+
         parent = item.parent.obj  # Test class/module
         node = item.obj  # Test case
         if config.getoption("napoleon"):


### PR DESCRIPTION
Hello!

The plugin seems to be in conflict with [pytest-black](https://github.com/shopkeep/pytest-black), a pytest integration for the [Black](https://github.com/ambv/black) code formatter.
Here is what I get when I try to use `pytest-azurepipelines` and `pytest-black` simultaneously:
<details><summary>Click to see the log</summary>

```bash
$ pytest --black
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.7.3, pytest-4.4.0, py-1.8.0, pluggy-0.9.0
rootdir: /home/george/github/test-project
plugins: black-0.3.5, azurepipelines-0.6.0
collecting ... INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/_pytest/main.py", line 209, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/_pytest/main.py", line 248, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/hooks.py", line 289, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/manager.py", line 68, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/manager.py", line 62, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/_pytest/main.py", line 258, in pytest_collection
INTERNALERROR>     return session.perform_collect()
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/_pytest/main.py", line 497, in perform_collect
INTERNALERROR>     session=self, config=self.config, items=items
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/hooks.py", line 289, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/manager.py", line 68, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/manager.py", line 62, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/george/.envs/test-env/lib/python3.7/site-packages/pytest_azurepipelines.py", line 28, in pytest_collection_modifyitems
INTERNALERROR>     parent = item.parent.obj  # Test class/module
INTERNALERROR> AttributeError: 'Session' object has no attribute 'obj'
##vso[results.publish type=JUnit;runTitle='Pytest results';]/home/george/github/test-project/test-output.xml

```

</details>

Steps to reproduce:
 - Install `pytest-black==0.3.5` and `pytest-azurepipelines==0.6.0`
 - Run pytest with the `--black` flag: `pytest --black`

pytest-black uses a [custom item class](https://github.com/shopkeep/pytest-black/blob/16aeee928e5120bffa226ad7a3870eb5ccb6f978/pytest_black.py#L41) which does not define `.obj` attribute, leading to the error above. This PR adds attribute checks to `pytest_collection_modifyitems()` so the invalid items get skipped. 