### PR TITLE
Refs #20: Make nodeID modification opt-in.

### DIFF
--- a/pytest_azurepipelines.py
+++ b/pytest_azurepipelines.py
@@ -42,8 +42,6 @@ def pytest_collection_modifyitems(session, config, items):
                 item._nodeid = "{0} [{1}]".format(suite_doc, node.__name__)
             elif case_doc and not suite_doc and hasattr(parent, "__name__"):
                 item._nodeid = "{0} [{1}]".format(parent.__name__, case_doc)
-            else:
-                item._nodeid = node.__name__
 
 
 def pytest_configure(config):

--- a/pytest_azurepipelines.py
+++ b/pytest_azurepipelines.py
@@ -33,15 +33,6 @@ def pytest_collection_modifyitems(session, config, items):
             )
             case_doc = node.__doc__.split("\n\n")[0] if node.__doc__ else None
             item._nodeid = "[{0}] {1}/{2}".format(case_doc, suite_doc, item.name)
-        else:
-            suite_doc = parent.__doc__.strip() if parent.__doc__ else None
-            case_doc = node.__doc__.strip() if node.__doc__ else None
-            if suite_doc and case_doc:
-                item._nodeid = "{0} [{1}]".format(suite_doc, case_doc)
-            elif suite_doc and not case_doc:
-                item._nodeid = "{0} [{1}]".format(suite_doc, node.__name__)
-            elif case_doc and not suite_doc and hasattr(parent, "__name__"):
-                item._nodeid = "{0} [{1}]".format(parent.__name__, case_doc)
 
 
 def pytest_configure(config):


### PR DESCRIPTION
`pytest_collection_modifyitems` sets `_nodeid` on the test item. This accommodates "napoleon"  docstring format, as well as introducing docstring-based nodeID formatting.

As per pytest-dev/pytest#5259, nodeID is intended to be a read-only property. pytest-azurepipeline's modification of _nodeid breaks plugins that rely on nodeid as a node identifier. 

I've retained the "napolean" option here on the assumption that it's being used by someone, even though it's relying on an internal that is meant to be readonly. I suspect the real fix here is to inject the test docstring as part of the *reporting* phase, rather than the collection phase - although that may not be possible with the metadata that is currently being passed from test Items to the report.

See #19 for an alternate approach to this problem (making the "clean", no-modification behavior opt-in).